### PR TITLE
Gemfile: hold back rack-test to 1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Ruby 1.9 or 2.2
-      if: matrix.ruby == '1.9' || matrix.ruby == '2.2'
+    - name: Install Ruby 1.9
+      if: matrix.ruby == '1.9'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -30,12 +30,12 @@ jobs:
       if: matrix.ruby == '1.9'
       run: gem update --system 2.7.11
 
-    - name: Install dependencies for Ruby 1.9, 2.2
-      if: matrix.ruby == '1.9' || matrix.ruby == '2.2'
+    - name: Install dependencies for Ruby 1.9
+      if: matrix.ruby == '1.9'
       run: bundle install
 
     - name: Install Ruby ${{ matrix.ruby }}, install and cache dependencies
-      if: matrix.ruby != '1.9' && matrix.ruby != '2.2'
+      if: matrix.ruby != '1.9'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Ruby 1.9
-      if: matrix.ruby == '1.9'
+    - name: Install Ruby 1.9 or 2.2
+      if: matrix.ruby == '1.9' || matrix.ruby == '2.2'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -29,12 +29,12 @@ jobs:
       if: matrix.ruby == '1.9'
       run: gem update --system 2.7.11
 
-    - name: Install dependencies for Ruby 1.9
-      if: matrix.ruby == '1.9'
+    - name: Install dependencies for Ruby 1.9, 2.2
+      if: matrix.ruby == '1.9' || matrix.ruby == '2.2'
       run: bundle install
 
     - name: Install Ruby ${{ matrix.ruby }}, install and cache dependencies
-      if: matrix.ruby != '1.9'
+      if: matrix.ruby != '1.9' && matrix.ruby != '2.2'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'rake'
 
 group :test do
-  gem 'rack-test'
+  gem 'rack-test', "~> 1.0"
   gem 'test-unit'
   gem 'shoulda'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,11 @@ gemspec
 gem 'rake'
 
 group :test do
-  gem 'rack-test', "~> 1.0"
+  if RUBY_VERSION < '2.3'
+    gem 'rack-test'
+  else
+    gem 'rack-test', '~> 1.0'
+  end
   gem 'test-unit'
   gem 'shoulda'
 end


### PR DESCRIPTION
This PR fixes the build in at least Ruby 3.3, by holding back rack-test to the version the gem was created with.

Fixes #5.