### PR TITLE
Require Rack 3.0+, Ruby 3.1+, bump version to 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,31 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04 ]
-        ruby: [ 1.9, '2.0', 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, ruby-head, jruby, truffleruby ]
+        os: [ ubuntu-latest ]
+        ruby: [ 3.1, 3.2, 3.3, ruby-head, jruby, truffleruby ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Ruby 1.9
-      if: matrix.ruby == '1.9'
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-
-    # Ruby 1.9 comes with RubyGems 1.8.23.2 but arbitrary metadata support in
-    # gemspec was added in RubyGems 2.0.0.
-    # RubyGems 2.7.11 is the last version to support Ruby 1.9.
-    - name: Update RubyGems for Ruby 1.9
-      if: matrix.ruby == '1.9'
-      run: gem update --system 2.7.11
-
-    - name: Install dependencies for Ruby 1.9
-      if: matrix.ruby == '1.9'
-      run: bundle install
-
     - name: Install Ruby ${{ matrix.ruby }}, install and cache dependencies
-      if: matrix.ruby != '1.9'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -50,6 +32,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ruby
     - run: gem build spinels-rack-ssl-enforcer
     - run: gem install *.gem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        ruby: [ 3.1, 3.2, 3.3, ruby-head, jruby, truffleruby ]
+        os:
+          - ubuntu-latest
+        ruby:
+          - 3.1
+          - 3.2
+          - 3.3
+          - ruby-head
+          - jruby
+          - truffleruby
+        rack:
+          - ~> 3.0.0
+          - stable
+          - head
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: ruby ${{ matrix.ruby }}, rack ${{ matrix.rack }})
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased](https://github.com/spinels/rack-ssl-enforcer/tree/HEAD)
 
-[Full Changelog](https://github.com/spinels/rack-ssl-enforcer/compare/v0.3.0...HEAD)
+[Full Changelog](https://github.com/spinels/rack-ssl-enforcer/compare/v1.0.0...HEAD)
+
+## [v1.0.0](https://github.com/spinels/rack-ssl-enforcer/tree/v1.0.0) (2024-08-01)
+[Full Changelog](https://github.com/spinels/rack-ssl-enforcer/compare/v0.3.0...v1.0.0)
+
+- Rack 3.0+ compatibility [#7](https://github.com/spinels/rack-ssl-enforcer/pull/7) ([dentarg](https://github.com/dentarg))
 
 ## [v0.3.0](https://github.com/spinels/rack-ssl-enforcer/tree/v0.3.0) (2022-01-09)
 [Full Changelog](https://github.com/spinels/rack-ssl-enforcer/compare/v0.2.9...v0.3.0)

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gemspec
 gem 'rake'
 
 group :test do
+  rack_version = ENV['rack'].to_s
+  rack_version = nil if rack_version.empty? || (rack_version == 'stable')
+  rack_version = { github: 'rack/rack' } if rack_version == 'head'
+  gem 'rack', rack_version
   gem 'rack-test'
   gem 'test-unit'
   gem 'shoulda'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,7 @@ gemspec
 gem 'rake'
 
 group :test do
-  if RUBY_VERSION < '2.3'
-    gem 'rack-test'
-  else
-    gem 'rack-test', '~> 1.0'
-  end
+  gem 'rack-test'
   gem 'test-unit'
   gem 'shoulda'
 end

--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -93,7 +93,7 @@ module Rack
       location = replace_host(location, req, @options[:redirect_to])
       redirect_to(location)
     rescue URI::InvalidURIError
-      [400, { 'Content-Type' => 'text/plain'}, []]
+      [400, { 'content-type' => 'text/plain'}, []]
     end
 
     def redirect_to(location)
@@ -102,7 +102,7 @@ module Rack
       body << @options[:redirect_html] if @options[:redirect_html].is_a?(String)
       body = @options[:redirect_html] if @options[:redirect_html].respond_to?('each')
 
-      [@options[:redirect_code] || 301, { 'Content-Type' => 'text/html', 'Location' => location }, body]
+      [@options[:redirect_code] || 301, { 'content-type' => 'text/html', 'location' => location }, body]
     end
 
     def ssl_request?(req)
@@ -181,15 +181,15 @@ module Rack
 
     # see http://en.wikipedia.org/wiki/HTTP_cookie#Cookie_theft_and_session_hijacking
     def flag_cookies_as_secure!(headers)
-      if cookies = headers['Set-Cookie']
+      if cookies = headers['set-cookie']
         # Support Rails 2.3 / Rack 1.1 arrays as headers
         unless cookies.is_a?(Array)
           cookies = cookies.split("\n")
         end
 
-        headers['Set-Cookie'] = cookies.map do |cookie|
+        headers['set-cookie'] = cookies.map do |cookie|
           cookie !~ /(^|;\s)secure($|;)/ ? "#{cookie}; secure" : cookie
-        end.join("\n")
+        end
       end
     end
 
@@ -200,7 +200,7 @@ module Rack
       value  = "max-age=#{opts[:expires]}"
       value += "; includeSubDomains" if opts[:subdomains]
       value += "; preload" if opts[:preload]
-      headers.merge!({ 'Strict-Transport-Security' => value })
+      headers.merge!({ 'strict-transport-security' => value })
     end
 
   end

--- a/lib/rack/ssl-enforcer/version.rb
+++ b/lib/rack/ssl-enforcer/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class SslEnforcer
-    VERSION = "0.3.0"
+    VERSION = "1.0.0"
   end
 end

--- a/spinels-rack-ssl-enforcer.gemspec
+++ b/spinels-rack-ssl-enforcer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = 'Rack::SslEnforcer is a simple Rack middleware to enforce ssl connections'
 
   s.required_rubygems_version = '>= 1.3.6'
-  s.required_ruby_version     = '>= 1.9.3'
+  s.required_ruby_version     = '>= 3.1.0'
 
   s.metadata     = { 'rubygems_mfa_required' => 'true' }
   s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE README.md]

--- a/spinels-rack-ssl-enforcer.gemspec
+++ b/spinels-rack-ssl-enforcer.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.summary     = 'A simple Rack middleware to enforce SSL'
   s.description = 'Rack::SslEnforcer is a simple Rack middleware to enforce ssl connections'
 
+  s.add_dependency 'rack', '>= 3.0.0'
+
   s.required_rubygems_version = '>= 1.3.6'
   s.required_ruby_version     = '>= 3.1.0'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,8 +16,8 @@ class Test::Unit::TestCase
 
   def mock_app(options_or_options_array = {})
     main_app = lambda { |env|
-      headers = {'Content-Type' => "text/html"}
-      headers['Set-Cookie'] = "id=1; path=/\ntoken=abc; path=/; secure; HttpOnly"
+      headers = {'content-type' => "text/html"}
+      headers['set-cookie'] = ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"]
       [200, headers, ['Hello world!']]
     }
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'test/unit'
 require 'shoulda'
+require 'rack/builder'
 require 'rack/mock'
 require 'rack/test'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 require 'shoulda'
 require 'rack/builder'
+require 'rack/lint'
 require 'rack/mock'
 require 'rack/test'
 

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -44,25 +44,25 @@ class TestRackSslEnforcer < Test::Unit::TestCase
 
     should 'secure cookies' do
       get 'https://www.example.org/'
-      assert_equal ["id=1; path=/; secure", "token=abc; path=/; secure; HttpOnly"], last_response.headers['Set-Cookie'].split("\n")
+      assert_equal ["id=1; path=/; secure", "token=abc; path=/; secure; HttpOnly"], last_response.headers['set-cookie']
     end
 
     should 'not set default HSTS headers to SSL requests' do
       get 'https://www.example.org/'
-      assert !last_response.headers["Strict-Transport-Security"]
+      assert !last_response.headers["strict-transport-security"]
     end
 
     should 'not set hsts headers to non-SSL requests' do
       get 'http://www.example.org/'
-      assert !last_response.headers["Strict-Transport-Security"]
+      assert !last_response.headers["strict-transport-security"]
     end
   end
 
   context 'With Rails 2.3 / Rack 1.1-style Array-based cookies' do
     setup do
       main_app = lambda { |env|
-        headers = {'Content-Type' => "text/html"}
-        headers['Set-Cookie'] = ["id=1; path=/", "token=abc; path=/; HttpOnly"]
+        headers = {'content-type' => "text/html"}
+        headers['set-cookie'] = ["id=1; path=/", "token=abc; path=/; HttpOnly"]
         [200, headers, ['Hello world!']]
       }
 
@@ -74,7 +74,7 @@ class TestRackSslEnforcer < Test::Unit::TestCase
 
     should 'secure cookies' do
       get 'https://www.example.org/'
-      assert_equal ["id=1; path=/; secure", "token=abc; path=/; HttpOnly; secure"], last_response.headers['Set-Cookie'].split("\n")
+      assert_equal ["id=1; path=/; secure", "token=abc; path=/; HttpOnly; secure"], last_response.headers['set-cookie']
     end
   end
 
@@ -708,22 +708,22 @@ class TestRackSslEnforcer < Test::Unit::TestCase
 
     should 'not set hsts for www.example.org (HTTP)' do
       get 'http://www.example.org/'
-      assert !last_response.headers["Strict-Transport-Security"]
+      assert !last_response.headers["strict-transport-security"]
     end
 
     should 'not set hsts for www.example.org (HTTPS)' do
       get 'https://www.example.org/'
-      assert !last_response.headers["Strict-Transport-Security"]
+      assert !last_response.headers["strict-transport-security"]
     end
 
     should 'not set hsts for abc.example.org (HTTP)' do
       get 'http://abc.example.org/'
-      assert !last_response.headers["Strict-Transport-Security"]
+      assert !last_response.headers["strict-transport-security"]
     end
 
     should 'not set hsts for abc.example.org (HTTPS)' do
       get 'https://abc.example.org/'
-      assert !last_response.headers["Strict-Transport-Security"]
+      assert !last_response.headers["strict-transport-security"]
     end
   end
 
@@ -792,17 +792,17 @@ class TestRackSslEnforcer < Test::Unit::TestCase
 
     should 'set expiry option' do
       get 'https://www.example.org/'
-      assert last_response.headers["Strict-Transport-Security"].include?("max-age=500")
+      assert last_response.headers["strict-transport-security"].include?("max-age=500")
     end
 
     should 'not include subdomains' do
       get 'https://www.example.org/'
-      assert !last_response.headers["Strict-Transport-Security"].include?("includeSubDomains")
+      assert !last_response.headers["strict-transport-security"].include?("includeSubDomains")
     end
 
     should 'set preload option' do
       get 'https://www.example.org'
-      assert last_response.headers["Strict-Transport-Security"].include?("preload")
+      assert last_response.headers["strict-transport-security"].include?("preload")
     end
   end
 
@@ -811,7 +811,7 @@ class TestRackSslEnforcer < Test::Unit::TestCase
 
     should 'not secure cookies but warn the user of the consequences' do
       get 'https://www.example.org/users/123/edit'
-      assert_equal ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"], last_response.headers['Set-Cookie'].split("\n")
+      assert_equal ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"], last_response.headers['set-cookie']
     end
   end
 


### PR DESCRIPTION
The rest as reached end of life: https://www.ruby-lang.org/en/downloads/